### PR TITLE
Add support for block LaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # LaTeXLM
 
-This repository contains a Chrome extension for rendering inline LaTeX on [NotebookLM](https://notebooklm.google.com/).
+This repository contains a Chrome extension for rendering LaTeX on [NotebookLM](https://notebooklm.google.com/). The extension supports both inline and block expressions.
+Inline math can be written using `$...$` or `\(...\)`, while block math uses `$$...$$` or `\[...\]`.
 
 The extension relies on the [KaTeX](https://katex.org/) runtime, which is **not included** in the repository. See [`notebooklm-latex-extension`](./notebooklm-latex-extension/) for instructions on downloading the KaTeX files and loading the extension.

--- a/notebooklm-latex-extension/README.md
+++ b/notebooklm-latex-extension/README.md
@@ -1,11 +1,11 @@
 # NotebookLM LaTeX Renderer
 
-This Chrome extension renders inline LaTeX expressions on [NotebookLM](https://notebooklm.google.com/) using KaTeX.
+This Chrome extension renders both inline and block LaTeX expressions on [NotebookLM](https://notebooklm.google.com/) using KaTeX.
 
 ## Files
 
 - `manifest.json` – Chrome extension manifest
-- `content.js` – Scans the page for `$...$` or `\(...\)` and renders them with KaTeX
+- `content.js` – Scans the page for LaTeX delimiters (`$...$`, `\(...\)`, `$$...$$`, `\[...\]`) and renders them with KaTeX
 - `katex.min.js`, `katex.min.css`, and `fonts/` – KaTeX runtime files (download separately)
 
 This directory does not include the KaTeX runtime. Download it yourself using `npm`:
@@ -24,7 +24,7 @@ Alternatively, grab the same files from a [KaTeX release](https://github.com/KaT
 2. Enable *Developer mode*.
 3. Ensure `katex.min.js`, `katex.min.css`, and the `fonts/` directory are present in this folder.
 4. Click **Load unpacked** and select this directory.
-5. Navigate to NotebookLM and the extension will automatically render inline LaTeX.
+5. Navigate to NotebookLM and the extension will automatically render both inline and block LaTeX.
 
 ## Development
 

--- a/notebooklm-latex-extension/content.js
+++ b/notebooklm-latex-extension/content.js
@@ -11,8 +11,10 @@ function getTextNodes(node) {
   return textNodes;
 }
 
-// Regex for inline LaTeX: $...$ or \( ... \)
-const latexRegex = /\$(.+?)\$|\\\((.+?)\\\)/g;
+// Regex for inline and block LaTeX:
+//  inline: $...$ or \(...\)
+//  block: $$...$$ or \[...\]
+const latexRegex = /\$\$([\s\S]+?)\$\$|\\\[([\s\S]+?)\\\]|\\\((.+?)\\\)|\$([^$]+?)\$/g;
 
 // Render LaTeX in a single text node
 function renderLatexInNode(node) {
@@ -28,10 +30,11 @@ function renderLatexInNode(node) {
     if (match.index > lastIndex) {
       frag.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
     }
-    const latex = match[1] || match[2];
+    const latex = match[1] || match[2] || match[3] || match[4];
+    const isBlock = !!(match[1] || match[2]);
     const span = document.createElement('span');
     try {
-      katex.render(latex, span, { throwOnError: false });
+      katex.render(latex, span, { throwOnError: false, displayMode: isBlock });
     } catch (e) {
       span.textContent = match[0];
     }


### PR DESCRIPTION
## Summary
- update regex to capture block math delimiters
- use displayMode when rendering block expressions
- document new delimiters in README files

## Testing
- `node --check notebooklm-latex-extension/content.js`
- `node - <<'EOF'
const r=/\$\$([\s\S]+?)\$\$|\\\[([\s\S]+?)\\\]|\\\((.+?)\\\)|\$([^$]+?)\$/g;
let s='Inline $y$ and block $$x^2$$ and bracket \\[z\\] and paren \\(w\\).';
let m; while((m=r.exec(s))!==null){console.log(m[0], !!(m[1]||m[2]), m[1]||m[2]||m[3]||m[4]);}
EOF

------
https://chatgpt.com/codex/tasks/task_e_684a0c9971fc832ea4ac58f8d248b7eb