### PR TITLE
Update setup docs with bundled KaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,13 @@
 This repository contains a Chrome extension for rendering LaTeX on [NotebookLM](https://notebooklm.google.com/). The extension supports both inline and block expressions.
 Inline math can be written using `$...$` or `\(...\)`, while block math uses `$$...$$` or `\[...\]`.
 
-The extension relies on the [KaTeX](https://katex.org/) runtime, which is **not included** in the repository. See [`notebooklm-latex-extension`](./notebooklm-latex-extension/) for instructions on downloading the KaTeX files and loading the extension.
+## Quick start
+
+The `notebooklm-latex-extension` directory already includes `katex.min.js`, `katex.min.css`, and the required fonts.
+
+1. Open Chrome and go to `chrome://extensions`.
+2. Enable *Developer mode*.
+3. Click **Load unpacked** and select `notebooklm-latex-extension`.
+4. Navigate to NotebookLM and LaTeX expressions will render automatically.
+
+To update the bundled KaTeX files, optionally run `npm install` inside `notebooklm-latex-extension` and copy over the new `katex.min.js`, `katex.min.css`, and `fonts/` directory.

--- a/notebooklm-latex-extension/README.md
+++ b/notebooklm-latex-extension/README.md
@@ -6,9 +6,9 @@ This Chrome extension renders both inline and block LaTeX expressions on [Notebo
 
 - `manifest.json` – Chrome extension manifest
 - `content.js` – Scans the page for LaTeX delimiters (`$...$`, `\(...\)`, `$$...$$`, `\[...\]`) and renders them with KaTeX
-- `katex.min.js`, `katex.min.css`, and `fonts/` – KaTeX runtime files (download separately)
+- `katex.min.js`, `katex.min.css`, and `fonts/` – KaTeX runtime files (included)
 
-This directory does not include the KaTeX runtime. Download it yourself using `npm`:
+The bundled KaTeX runtime was fetched from npm. If you want to upgrade to a newer version, run:
 
 ```bash
 npm install katex
@@ -16,15 +16,12 @@ cp node_modules/katex/dist/katex.min.js node_modules/katex/dist/katex.min.css -t
 cp -r node_modules/katex/dist/fonts .
 ```
 
-Alternatively, grab the same files from a [KaTeX release](https://github.com/KaTeX/KaTeX/releases) and copy them here.
-
-## Setup
+## Quick start
 
 1. Open Chrome and navigate to `chrome://extensions`.
 2. Enable *Developer mode*.
-3. Ensure `katex.min.js`, `katex.min.css`, and the `fonts/` directory are present in this folder.
-4. Click **Load unpacked** and select this directory.
-5. Navigate to NotebookLM and the extension will automatically render both inline and block LaTeX.
+3. Click **Load unpacked** and select this directory.
+4. Visit NotebookLM and math will automatically render.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- remove warning that KaTeX runtime is missing
- add quick-start instructions referencing bundled KaTeX files
- show how to optionally update KaTeX via npm

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a0e3cb5cc832e9e9ff7fcb74effa5