### PR TITLE
Fix MathJax conversion leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LaTeXLM
 
-This repository provides a small Chrome extension that renders LaTeX on [NotebookLM](https://notebooklm.google.com/). Both inline math (`$...$` or `\(...\)`) and block math (`$$...$$` or `\[...\]`) are supported using the [KaTeX](https://katex.org/) runtime.
+This repository provides a small Chrome extension that renders LaTeX on [NotebookLM](https://notebooklm.google.com/). Both inline math (`$...$` or `\(...\)`) and block math (`$$...$$` or `\[...\]`) are supported using the [MathJax](https://www.mathjax.org/) runtime.
 
 ## Quick start
 
@@ -10,7 +10,7 @@ This repository provides a small Chrome extension that renders LaTeX on [Noteboo
 4. Click **Load unpacked** and select the `notebooklm-latex-extension` folder.
 5. Visit NotebookLM and your LaTeX expressions will render automatically.
 
-The KaTeX runtime (`katex.min.js`, `katex.min.css`, and the `fonts/` directory) is already bundled in the extension directory. If you would like to upgrade to a newer KaTeX release run `npm install` inside `notebooklm-latex-extension` and copy the updated files from `node_modules/katex/dist`.
+The MathJax runtime (`tex-mml-chtml.js` and the `fonts/` directory) is already bundled in the extension directory. If you would like to upgrade to a newer MathJax release run `npm install` inside `notebooklm-latex-extension` and copy the updated files from `node_modules/mathjax/es5`.
 
 ## Packaging
 

--- a/notebooklm-latex-extension/README.md
+++ b/notebooklm-latex-extension/README.md
@@ -8,7 +8,7 @@ This Chrome extension renders both inline and block LaTeX expressions on [Notebo
 - `content.js` – Scans the page for LaTeX delimiters (`$...$`, `\(...\)`, `$$...$$`, `\[...\]`) and renders them with MathJax
 - `tex-mml-chtml.js` and `fonts/` – MathJax runtime files
 
-The KaTeX files were fetched from npm. To update them run:
+The MathJax files were fetched from npm. To update them run:
 
 ```bash
 npm install mathjax

--- a/notebooklm-latex-extension/manifest.json
+++ b/notebooklm-latex-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "NotebookLM LaTeX Renderer",
   "version": "1.0",
-  "description": "Renders inline LaTeX in NotebookLM using KaTeX.",
+  "description": "Renders inline LaTeX in NotebookLM using MathJax.",
   "permissions": [],
   "content_scripts": [
     {
@@ -10,18 +10,14 @@
         "https://notebooklm.google.com/*"
       ],
       "js": [
-        "katex.min.js",
+        "tex-mml-chtml.js",
         "content.js"
-      ],
-      "css": [
-        "katex.min.css"
       ]
     }
   ],
   "web_accessible_resources": [
     {
       "resources": [
-        "katex.min.css",
         "fonts/*"
       ],
       "matches": [


### PR DESCRIPTION
## Summary
- update docs to reference MathJax instead of KaTeX
- load `tex-mml-chtml.js` from the extension manifest

## Testing
- `npm install --no-progress`
- `npm test` *(fails: Missing script)*
- `node -e "const fs=require('fs');JSON.parse(fs.readFileSync('notebooklm-latex-extension/manifest.json','utf8'));console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_684a155a4380832eb20f01e4d26c0286