### PR TITLE
Improve KaTeX regex and docs

### DIFF
--- a/notebooklm-latex-extension/README.md
+++ b/notebooklm-latex-extension/README.md
@@ -12,7 +12,8 @@ The KaTeX files were fetched from npm. To update them run:
 
 ```bash
 npm install katex
-cp node_modules/katex/dist/katex.min.js node_modules/katex/dist/katex.min.css -t .
+cp node_modules/katex/dist/katex.min.js .
+cp node_modules/katex/dist/katex.min.css .
 cp -r node_modules/katex/dist/fonts .
 ```
 
@@ -22,6 +23,13 @@ cp -r node_modules/katex/dist/fonts .
 2. Enable *Developer mode*.
 3. Click **Load unpacked** and select this directory.
 4. Visit NotebookLM and math will automatically render.
+
+### Tips
+
+* For best results place block math (e.g. `$$...$$`) on its own line so the
+  entire expression falls within a single text node. Inline math works when
+  directly adjacent to other characters, but you may see fewer rendering issues
+  if there is a small amount of surrounding whitespace.
 
 ## Packaging
 

--- a/notebooklm-latex-extension/content.js
+++ b/notebooklm-latex-extension/content.js
@@ -14,7 +14,9 @@ function getTextNodes(node) {
 // Regex for inline and block LaTeX:
 //  inline: $...$ or \(...\)
 //  block: $$...$$ or \[...\]
-const latexRegex = /\$\$([\s\S]+?)\$\$|\\\[([\s\S]+?)\\\]|\\\((.+?)\\\)|\$([^$]+?)\$/g;
+// Escaped delimiters like `\$` should not be treated as math. We use
+// negative lookbehind to ensure `$` tokens are not preceded by a backslash.
+const latexRegex = /(?<!\\)\$\$([\s\S]+?)(?<!\\)\$\$|\\\[([\s\S]+?)\\\]|\\\((.+?)\\\)|(?<!\\)\$([^$]+?)(?<!\\)\$/g;
 
 // Render LaTeX in a single text node
 function renderLatexInNode(node) {


### PR DESCRIPTION
## Summary
- ignore escaped dollar delimiters when parsing LaTeX
- clarify how to copy KaTeX assets and how to format math

## Testing
- `npm install --silent`
- `node --check content.js`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a1b6f92a4832ea32a4343f5acd34f