### PR TITLE
Improve parsing for punctuation and spaces

### DIFF
--- a/notebooklm-latex-extension/README.md
+++ b/notebooklm-latex-extension/README.md
@@ -12,7 +12,8 @@ The KaTeX files were fetched from npm. To update them run:
 
 ```bash
 npm install katex
-cp node_modules/katex/dist/katex.min.js node_modules/katex/dist/katex.min.css -t .
+cp node_modules/katex/dist/katex.min.js .
+cp node_modules/katex/dist/katex.min.css .
 cp -r node_modules/katex/dist/fonts .
 ```
 
@@ -22,6 +23,16 @@ cp -r node_modules/katex/dist/fonts .
 2. Enable *Developer mode*.
 3. Click **Load unpacked** and select this directory.
 4. Visit NotebookLM and math will automatically render.
+
+### Tips
+
+* For best results place block math (e.g. `$$...$$`) on its own line so the
+  entire expression falls within a single text node. Inline math works when
+  directly adjacent to other characters, but you may see fewer rendering issues
+  if there is a small amount of surrounding whitespace.
+* Ending a sentence with inline math like `$x^2$.` now renders correctly.
+  Block math with spaces inside the delimiters (e.g. `$$ something $$`) is also
+  supported.
 
 ## Packaging
 

--- a/notebooklm-latex-extension/content.js
+++ b/notebooklm-latex-extension/content.js
@@ -14,7 +14,12 @@ function getTextNodes(node) {
 // Regex for inline and block LaTeX:
 //  inline: $...$ or \(...\)
 //  block: $$...$$ or \[...\]
-const latexRegex = /\$\$([\s\S]+?)\$\$|\\\[([\s\S]+?)\\\]|\\\((.+?)\\\)|\$([^$]+?)\$/g;
+// Escaped delimiters like `\$` should not be treated as math. We use
+// negative lookbehind so `$` tokens are ignored when preceded by a backslash.
+// Closing delimiters must be followed by whitespace, punctuation or the end of
+// the node so that expressions like `$x$y` are not parsed incorrectly.
+const latexRegex =
+  /(?<!\\)\$\$([\s\S]+?)(?<!\\)\$\$(?=\W|$)|\\\[([\s\S]+?)\\\]|\\\((.+?)\\\)|(?<!\\)\$([^$]+?)(?<!\\)\$(?=\W|$)/g;
 
 // Render LaTeX in a single text node
 function renderLatexInNode(node) {
@@ -30,7 +35,7 @@ function renderLatexInNode(node) {
     if (match.index > lastIndex) {
       frag.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
     }
-    const latex = match[1] || match[2] || match[3] || match[4];
+    const latex = (match[1] || match[2] || match[3] || match[4]).trim();
     const isBlock = !!(match[1] || match[2]);
     const span = document.createElement('span');
     try {


### PR DESCRIPTION
## Summary
- refine regex to allow punctuation after closing delimiters and ignore $x$y cases
- trim captured LaTeX strings before rendering
- note in README that inline math at sentence end and spaced block math are supported

## Testing
- `npm install --silent`
- `node --check content.js`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684a1b6f92a4832ea32a4343f5acd34f