### PR TITLE
Switch NotebookLM extension to MathJax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LaTeXLM
 
-This repository provides a small Chrome extension that renders LaTeX on [NotebookLM](https://notebooklm.google.com/). Both inline math (`$...$` or `\(...\)`) and block math (`$$...$$` or `\[...\]`) are supported using the [KaTeX](https://katex.org/) runtime.
+This repository provides a small Chrome extension that renders LaTeX on [NotebookLM](https://notebooklm.google.com/). Both inline math (`$...$` or `\(...\)`) and block math (`$$...$$` or `\[...\]`) are rendered with the bundled [MathJax](https://www.mathjax.org/) runtime.
 
 ## Quick start
 
@@ -10,7 +10,7 @@ This repository provides a small Chrome extension that renders LaTeX on [Noteboo
 4. Click **Load unpacked** and select the `notebooklm-latex-extension` folder.
 5. Visit NotebookLM and your LaTeX expressions will render automatically.
 
-The KaTeX runtime (`katex.min.js`, `katex.min.css`, and the `fonts/` directory) is already bundled in the extension directory. If you would like to upgrade to a newer KaTeX release run `npm install` inside `notebooklm-latex-extension` and copy the updated files from `node_modules/katex/dist`.
+The MathJax runtime (`mathjax.js`) is already bundled in the extension directory. If you would like to upgrade to a newer MathJax release run `npm install` inside `notebooklm-latex-extension` and copy the updated file from `node_modules/mathjax-full/es5`.
 
 ## Packaging
 

--- a/notebooklm-latex-extension/README.md
+++ b/notebooklm-latex-extension/README.md
@@ -1,20 +1,18 @@
 # NotebookLM LaTeX Renderer
 
-This Chrome extension renders both inline and block LaTeX expressions on [NotebookLM](https://notebooklm.google.com/) using KaTeX.
+This Chrome extension renders both inline and block LaTeX expressions on [NotebookLM](https://notebooklm.google.com/) using MathJax.
 
 ## Files
 
 - `manifest.json` – Chrome extension manifest
-- `content.js` – Scans the page for LaTeX delimiters (`$...$`, `\(...\)`, `$$...$$`, `\[...\]`) and renders them with KaTeX
-- `katex.min.js`, `katex.min.css`, and `fonts/` – KaTeX runtime files
+- `content.js` – Invokes MathJax to typeset LaTeX on the page
+- `mathjax.js` – Bundled MathJax runtime
 
-The KaTeX files were fetched from npm. To update them run:
+The MathJax file was fetched from npm. To update it run:
 
 ```bash
-npm install katex
-cp node_modules/katex/dist/katex.min.js .
-cp node_modules/katex/dist/katex.min.css .
-cp -r node_modules/katex/dist/fonts .
+npm install mathjax-full
+cp node_modules/mathjax-full/es5/tex-chtml.js mathjax.js
 ```
 
 ## Quick start

--- a/notebooklm-latex-extension/content.js
+++ b/notebooklm-latex-extension/content.js
@@ -1,73 +1,11 @@
-// Helper: Find all text nodes under a given node
-function getTextNodes(node) {
-  let textNodes = [];
-  if (node.nodeType === Node.TEXT_NODE) {
-    textNodes.push(node);
-  } else {
-    for (let child of node.childNodes) {
-      textNodes = textNodes.concat(getTextNodes(child));
-    }
-  }
-  return textNodes;
+function typeset() {
+  MathJax.typesetPromise();
 }
 
-// Regex for inline and block LaTeX:
-//  inline: $...$ or \(...\)
-//  block: $$...$$ or \[...\]
-// Escaped delimiters like `\$` should not be treated as math. We use
-// negative lookbehind so `$` tokens are ignored when preceded by a backslash.
-// Closing delimiters must be followed by whitespace, punctuation or the end of
-// the node so that expressions like `$x$y` are not parsed incorrectly.
-const latexRegex =
-  /(?<!\\)\$\$([\s\S]+?)(?<!\\)\$\$(?=\W|$)|\\\[([\s\S]+?)\\\]|\\\((.+?)\\\)|(?<!\\)\$([^$]+?)(?<!\\)\$(?=\W|$)/g;
-
-// Render LaTeX in a single text node
-function renderLatexInNode(node) {
-  const text = node.textContent;
-  let match, lastIndex = 0;
-  const parent = node.parentNode;
-  const frag = document.createDocumentFragment();
-  latexRegex.lastIndex = 0;
-  let found = false;
-
-  while ((match = latexRegex.exec(text)) !== null) {
-    found = true;
-    if (match.index > lastIndex) {
-      frag.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
-    }
-    const latex = (match[1] || match[2] || match[3] || match[4]).trim();
-    const isBlock = !!(match[1] || match[2]);
-    const span = document.createElement('span');
-    try {
-      katex.render(latex, span, { throwOnError: false, displayMode: isBlock });
-    } catch (e) {
-      span.textContent = match[0];
-    }
-    frag.appendChild(span);
-    lastIndex = latexRegex.lastIndex;
-  }
-  if (found && lastIndex < text.length) {
-    frag.appendChild(document.createTextNode(text.slice(lastIndex)));
-  }
-  if (found) {
-    parent.replaceChild(frag, node);
-  }
+if (window.MathJax) {
+  MathJax.startup.promise.then(() => {
+    typeset();
+    const observer = new MutationObserver(() => typeset());
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
 }
-
-// Scan and render all LaTeX on the page
-function renderAllLatex() {
-  const root = document.body;
-  const textNodes = getTextNodes(root);
-  for (const node of textNodes) {
-    renderLatexInNode(node);
-  }
-}
-
-// Initial render
-renderAllLatex();
-
-// Re-render on DOM changes for dynamic content
-const observer = new MutationObserver(() => {
-  renderAllLatex();
-});
-observer.observe(document.body, { childList: true, subtree: true });

--- a/notebooklm-latex-extension/manifest.json
+++ b/notebooklm-latex-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "NotebookLM LaTeX Renderer",
   "version": "1.0",
-  "description": "Renders inline LaTeX in NotebookLM using KaTeX.",
+  "description": "Renders LaTeX in NotebookLM using MathJax.",
   "permissions": [],
   "content_scripts": [
     {
@@ -10,24 +10,12 @@
         "https://notebooklm.google.com/*"
       ],
       "js": [
-        "katex.min.js",
+        "mathjax-config.js",
+        "mathjax.js",
         "content.js"
-      ],
-      "css": [
-        "katex.min.css"
       ]
     }
   ],
-  "web_accessible_resources": [
-    {
-      "resources": [
-        "katex.min.css",
-        "fonts/*"
-      ],
-      "matches": [
-        "https://notebooklm.google.com/*"
-      ]
-    }
-  ],
+  "web_accessible_resources": [],
   "homepage_url": "https://github.com/user/LaTeXLM"
 }

--- a/notebooklm-latex-extension/mathjax-config.js
+++ b/notebooklm-latex-extension/mathjax-config.js
@@ -1,0 +1,9 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [['$', '$'], ['\\(', '\\)']],
+    displayMath: [['$$', '$$'], ['\\[', '\\]']]
+  },
+  startup: {
+    typeset: false
+  }
+};


### PR DESCRIPTION
## Summary
- load a MathJax configuration prior to the runtime
- replace the KaTeX renderer with MathJax
- update extension manifest to reference MathJax assets
- document MathJax usage in README files

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a21b53c70832e9067dc0b4baa19af