### PR TITLE
Fix rendering for multi-line block formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LaTeXLM
 
-This repository provides a small Chrome extension that renders LaTeX on [NotebookLM](https://notebooklm.google.com/). Both inline math (`$...$` or `\(...\)`) and block math (`$$...$$` or `\[...\]`) are rendered with the bundled [MathJax](https://www.mathjax.org/) runtime.
+This repository provides a small Chrome extension that renders LaTeX on [NotebookLM](https://notebooklm.google.com/). Both inline math (`$...$` or `\(...\)`) and block math (`$$...$$` or `\[...\]`) are rendered with the bundled [MathJax](https://www.mathjax.org/) runtime. Block expressions can span multiple lines separated by newlines.
 
 ## Quick start
 

--- a/notebooklm-latex-extension/README.md
+++ b/notebooklm-latex-extension/README.md
@@ -1,6 +1,6 @@
 # NotebookLM LaTeX Renderer
 
-This Chrome extension renders both inline and block LaTeX expressions on [NotebookLM](https://notebooklm.google.com/) using MathJax.
+This Chrome extension renders both inline and block LaTeX expressions on [NotebookLM](https://notebooklm.google.com/) using MathJax. Block formulas may span multiple lines.
 
 ## Files
 

--- a/notebooklm-latex-extension/content.js
+++ b/notebooklm-latex-extension/content.js
@@ -1,4 +1,28 @@
+function mergeMultilineDisplayMath(root = document.body) {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+  let node;
+  while ((node = walker.nextNode())) {
+    if (node.textContent.trim() === '$$') {
+      const start = node;
+      const between = [];
+      const remove = [];
+      while ((node = walker.nextNode())) {
+        if (node.textContent.trim() === '$$') {
+          break;
+        }
+        between.push(node.textContent);
+        remove.push(node);
+      }
+      if (!node) return; // unmatched
+      remove.forEach(n => n.parentNode.removeChild(n));
+      node.parentNode.removeChild(node); // closing $$
+      start.textContent = '$$' + between.join('\n') + '$$';
+    }
+  }
+}
+
 function typeset() {
+  mergeMultilineDisplayMath();
   MathJax.typesetPromise();
 }
 


### PR DESCRIPTION
## Summary
- revert previous changes
- allow block math separated by newlines by collapsing $$ regions in `content.js`
- mention multi-line math in documentation

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a2582261c832eb10d8e116b796b59